### PR TITLE
Add utils for executing terraform with Python

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,83 @@
+import os
+import stat
+from textwrap import dedent
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from tests.utils import build_terraform_command, terraform_deploy, TerraformLogLevel
+
+
+class TestBuildTerraformCommand(TestCase):
+    def test_happy_path(self) -> None:
+        expected_terraform_command = """\
+            #!/bin/bash
+            set -ex
+            TF_WORKSPACE=test terraform -chdir=/some/module/path init -upgrade -input=false
+            TF_WORKSPACE=test TF_LOG=INFO terraform -chdir=/some/module/path apply --auto-approve -var-file=test.tfvars
+        """
+        self.assertEqual(
+            dedent(expected_terraform_command),
+            build_terraform_command(
+                terraform_workspace='test',
+                terraform_vars_file='test.tfvars',
+                terraform_vars={},
+                module_path='/some/module/path',
+                log_level=TerraformLogLevel.INFO,
+            ),
+        )
+
+    def test_single_terraform_vars(self) -> None:
+        expected_terraform_command = """\
+            #!/bin/bash
+            set -ex
+            TF_WORKSPACE=test terraform -chdir=/some/module/path init -upgrade -input=false
+            TF_WORKSPACE=test TF_LOG=INFO terraform -chdir=/some/module/path apply --auto-approve -var-file=test.tfvars -var='hello=world'
+        """
+        self.assertEqual(
+            dedent(expected_terraform_command),
+            build_terraform_command(
+                terraform_workspace='test',
+                terraform_vars_file='test.tfvars',
+                terraform_vars={'hello': 'world'},
+                module_path='/some/module/path',
+                log_level=TerraformLogLevel.INFO,
+            ),
+        )
+
+    def test_multiple_terraform_vars(self) -> None:
+        expected_terraform_command = """\
+            #!/bin/bash
+            set -ex
+            TF_WORKSPACE=test terraform -chdir=/some/module/path init -upgrade -input=false
+            TF_WORKSPACE=test TF_LOG=INFO terraform -chdir=/some/module/path apply --auto-approve -var-file=test.tfvars -var='hello=world' -var='wee=womp'
+        """
+        self.assertEqual(
+            dedent(expected_terraform_command),
+            build_terraform_command(
+                terraform_workspace='test',
+                terraform_vars_file='test.tfvars',
+                terraform_vars={'hello': 'world', 'wee': 'womp'},
+                module_path='/some/module/path',
+                log_level=TerraformLogLevel.INFO,
+            ),
+        )
+
+
+class TestTerraformDeploy(TestCase):
+    @patch('tests.utils.os.chmod')
+    @patch('tests.utils.os.execvp')
+    def test_happy_path(self, mock_os_execvp: Mock, mock_os_chmod: Mock) -> None:
+        terraform_deploy(
+            terraform_workspace='test',
+            terraform_vars_file='test.tfvars',
+            terraform_vars={},
+            module_path='/some/module/path',
+            log_level=TerraformLogLevel.INFO,
+        )
+        mock_os_execvp.assert_called_once()
+        mock_os_chmod.assert_called_once()
+
+        # Ensure the script written to disk is executable
+        _, perm_bits = mock_os_chmod.mock_calls[0][1]
+        filemode: str = stat.filemode(perm_bits)
+        self.assertEqual('-rwx------', filemode)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,76 @@
+from enum import Enum
+import os
+import stat
+from tempfile import NamedTemporaryFile
+
+
+class TerraformLogLevel(Enum):
+    TRACE = 'TRACE'
+    DEBUG = 'DEBUG'
+    INFO = 'INFO'
+    WARN = 'WARN'
+    ERROR = 'ERROR'
+
+
+def build_setup_commands(terraform_workspace: str, module_path: str) -> str:
+    command = '#!/bin/bash\nset -ex\n'
+    command += (
+        f'TF_WORKSPACE={terraform_workspace} terraform -chdir={module_path} init -upgrade'
+        ' -input=false\n'
+    )
+    return command
+
+
+def build_terraform_command(
+    terraform_workspace: str,
+    terraform_vars_file: str,
+    terraform_vars: dict[str, str],
+    module_path: str,
+    log_level: TerraformLogLevel,
+) -> str:
+    terraform_command = build_setup_commands(
+        terraform_workspace=terraform_workspace, module_path=module_path
+    )
+    terraform_command += (
+        f'TF_WORKSPACE={terraform_workspace} TF_LOG={log_level.name} terraform'
+        f' -chdir={module_path}'
+        ' apply --auto-approve'
+        f' -var-file={terraform_vars_file}'
+    )
+
+    # Add extra terraform variables to the command
+    for key, value in terraform_vars.items():
+        terraform_command += f" -var='{key}={value}'"
+
+    terraform_command += '\n'
+    return terraform_command
+
+
+def terraform_deploy(
+    terraform_workspace: str,
+    terraform_vars_file: str,
+    terraform_vars: dict[str, str],
+    module_path: str,
+    log_level: TerraformLogLevel,
+) -> None:
+    """Deploy a terraform module given a specified module path."""
+    script_file = NamedTemporaryFile()
+    try:
+        with open(script_file.name, mode='w') as f:
+            f.write(
+                build_terraform_command(
+                    terraform_workspace=terraform_workspace,
+                    terraform_vars_file=terraform_vars_file,
+                    terraform_vars=terraform_vars,
+                    module_path=module_path,
+                    log_level=log_level,
+                )
+            )
+        # Make the script executable
+        st = os.stat(script_file.name)
+        os.chmod(script_file.name, st.st_mode | stat.S_IEXEC)
+
+        # Execute the terraform script
+        os.execvp('/bin/sh', ['/bin/sh', script_file.name])
+    finally:
+        script_file.close()


### PR DESCRIPTION
This adds utils for executing Terraform in Python which can be used like this:
```python3
from tests.utils import terraform_deploy, TerraformLogLevel

terraform_deploy(
    terraform_workspace='test',
    terraform_vars_file='test.tfvars',
    terraform_vars={'variable1_key': 'variable1_value'},
    module_path='/some/module/path',
    log_level=TerraformLogLevel.INFO,
)
```

The `terraform_vars` kwarg can also be empty:
```python3
terraform_deploy(
    terraform_workspace='test',
    terraform_vars_file='test.tfvars',
    terraform_vars={},
    module_path='/some/module/path',
    log_level=TerraformLogLevel.INFO,
)
```

This will be later used to execute Terraform modules in unit tests.