### PR TITLE
Inject AWS secrets into the test runner

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,12 +10,15 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
-          cache: 'pip'
+          python-version: "3.10"
+          cache: "pip"
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r tests/requirements.txt
       - name: Test with pytest
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           python -m pytest tests/


### PR DESCRIPTION
Inject AWS secrets into the test runner as environment variables. This will allow the test runner to communicate with the test AWS account.

It looks like my editor linted the yaml file as well.