### PR TITLE
Reorganize tests to avoid code duplication

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,7 +26,7 @@ import os
 import stat
 import subprocess
 from tempfile import NamedTemporaryFile
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 
 class TerraformLogLevel(Enum):
@@ -49,7 +49,7 @@ def build_setup_commands(terraform_workspace: str, module_path: str) -> str:
 def build_terraform_command(
     terraform_workspace: str,
     terraform_vars_file: str,
-    terraform_vars: dict[str, str],
+    terraform_vars: Dict[str, Union[str, int]],
     module_path: str,
     log_level: TerraformLogLevel,
     cmd: str,
@@ -77,7 +77,7 @@ class TerraformExecutor(object):
         self,
         terraform_workspace: str,
         terraform_vars_file: str,
-        terraform_vars: Dict[str, str],
+        terraform_vars: Dict[str, Union[str, int]],
         module_path: str,
         log_level: TerraformLogLevel,
     ):


### PR DESCRIPTION
Reorganize tests to avoid code duplication.

Test cases will now be added to `BaseClusterTests` and can be executed by any concrete class which inherits this class. All concrete classes must implement the `create_qumulo_terraform_executor` class method, which defines how the Qumulo file system will be created in the test setup.

To skip instantiating the `BaseClusterTests` class and avoid running tests directly, we are using ` __test__ = False` to have pytest skip the class. The subclasses where tests will run must have ` __test__ = True`.

This will also enable us to parallelize tests in the future.

This is an example of creating a new environment for running tests. All tests in `BaseClusterTests` will be executed against this configuration:

```python3
class TestMyQumuloConfiguration(BaseClusterTests):
    __test__ = True

    @classmethod
    def create_qumulo_terraform_executor(cls) -> TerraformExecutor:
        # Build a Qumulo cluster TerraformExecutor here with a custom configuration
        return TerraformExecutor(
            ...
        )

```