### PR TITLE
Timeout Github action workflows after 90 minutes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.x


### PR DESCRIPTION
... what it says on the tin ...