### PR TITLE
Avoid using uuids in deployment names since deployment names are already unique

### DIFF
--- a/tests/test_terraform.py
+++ b/tests/test_terraform.py
@@ -164,7 +164,7 @@ class TestSingleAZ(BaseClusterTests):
             terraform_workspace="test",
             terraform_vars_file="terraform_tests.tfvars",
             terraform_vars={
-                "deployment_name": f"cloud-q-test-single-az-{uuid.uuid4()}"[:32],
+                "deployment_name": "cloud-q-test-single-az",
                 "aws_vpc_id": cls.vpc_executor_outputs["vpc_id"],
                 "private_subnet_id": cls.vpc_executor_outputs["private_subnet_ids"][0],
                 "public_subnet_id": cls.vpc_executor_outputs["public_subnet_ids"][0],
@@ -186,7 +186,7 @@ class TestMultiAZ(BaseClusterTests):
             terraform_workspace="test",
             terraform_vars_file="terraform_tests.tfvars",
             terraform_vars={
-                "deployment_name": f"cloud-q-test-multi-az-{uuid.uuid4()}"[:32],
+                "deployment_name": "cloud-q-test-multi-az",
                 "aws_vpc_id": cls.vpc_executor_outputs["vpc_id"],
                 "private_subnet_id": ",".join(
                     cls.vpc_executor_outputs["private_subnet_ids"]


### PR DESCRIPTION
Closes #30 