### PR TITLE
Use latest Qumulo version in tests and update all cluster version references to 5.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ module "qumulo_cloud_q" {
   q_marketplace_type       = "1TB-Usable-All-Flash"
   # ***** Qumulo Sidecar Variables *****
   # q_sidecar_version                 - The software verison for the sidecar must match the cluster.  This variable can be used to update the sidecar software version post deployment.
-  q_sidecar_version = "5.1.0.1"
+  q_sidecar_version = "5.3.0"
   # ****************************** Marketplace Type Selection Dependencies ******************************
   # ***** Qumulo Cluster Config Options *****
   # q_disk_config                     - Specify the disk config only if using Marketplace types of 'Custom-' or 'Specified-AMI-ID'  Valid disk configs are:

--- a/examples/standard.tf
+++ b/examples/standard.tf
@@ -36,7 +36,7 @@ module "qumulo_cloud_q" {
   q_marketplace_type       = "1TB-Usable-All-Flash"
   # ***** Qumulo Sidecar Variables *****
   # q_sidecar_version                 - The software verison for the sidecar must match the cluster.  This variable can be used to update the sidecar software version post deployment.
-  q_sidecar_version = "5.1.0.1"
+  q_sidecar_version = "5.3.0"
   # ****************************** Marketplace Type Selection Dependencies ******************************
   # ***** Qumulo Cluster Config Options *****
   # q_disk_config                     - Specify the disk config only if using Marketplace types of 'Custom-' or 'Specified-AMI-ID'  Valid disk configs are:

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -36,7 +36,7 @@ term_protection   = true
 #                                       Custom-1TB-6PB or Specified-AMI-ID
 q_cluster_admin_password = "!MyPwd123"
 q_cluster_name           = "Cloud-Q"
-q_cluster_version        = "5.2.5"
+q_cluster_version        = "5.3.0"
 q_instance_type          = "m5.2xlarge"
 q_marketplace_type       = "1TB-Usable-All-Flash"
 
@@ -48,7 +48,7 @@ q_marketplace_type       = "1TB-Usable-All-Flash"
 q_local_zone_or_outposts    = false
 q_sidecar_private_subnet_id = null
 q_sidecar_provision         = false
-q_sidecar_version           = "5.2.5"
+q_sidecar_version           = "5.3.0"
 
 # ****************************** Marketplace Type Selection Dependencies ******************************
 # ***** Qumulo Cluster Config Options *****

--- a/terraform_tests.tfvars
+++ b/terraform_tests.tfvars
@@ -26,9 +26,9 @@ term_protection = false
 #                                       Custom-1TB-6PB or Specified-AMI-ID
 q_cluster_admin_password = "!MyPwd123"
 q_cluster_name           = "Cloud-Q"
-q_cluster_version        = "5.1.0.1"
-q_instance_type          = "m5.xlarge"
-q_marketplace_type       = "1TB-Usable-All-Flash"
+# q_cluster_version        = "5.1.0.1"
+q_instance_type    = "m5.xlarge"
+q_marketplace_type = "1TB-Usable-All-Flash"
 
 # ***** Qumulo Sidecar Variables *****
 # q_local_zone_or_outposts          - true if deploying the cluster in a local zone or on Outposts.
@@ -38,7 +38,7 @@ q_marketplace_type       = "1TB-Usable-All-Flash"
 q_local_zone_or_outposts    = false
 q_sidecar_private_subnet_id = null
 q_sidecar_provision         = false
-q_sidecar_version           = "5.1.0.1"
+# q_sidecar_version           = "5.3.0"
 
 # ****************************** Marketplace Type Selection Dependencies ******************************
 # ***** Qumulo Cluster Config Options *****

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -22,7 +22,7 @@ py==1.11.0
 pyparsing==3.0.9
 pytest==7.2.0
 pytest-cov==4.0.0
-qumulo-api==5.1.0.1
+qumulo-api==5.3.0
 requests==2.28.1
 retry==0.9.2
 tomli==2.0.1

--- a/variables.tf
+++ b/variables.tf
@@ -129,7 +129,7 @@ variable "q_cluster_name" {
 variable "q_cluster_version" {
   description = "Qumulo cluster software version"
   type        = string
-  default     = "5.1.0.1"
+  default     = "5.3.0"
   validation {
     condition     = can(regex("^((4\\.[2-3]\\.[0-9][0-9]?\\.?[0-9]?[0-9]?)|([5-9][0-9]?\\.[0-3]\\.[0-9][0-9]?\\.?[0-9]?[0-9]?))$", var.q_cluster_version))
     error_message = "The q_cluster_version 5.1.0.1 or greater. Examples: 5.1.0.1, 5.1.2, 5.3.10."
@@ -389,7 +389,7 @@ variable "q_sidecar_user_name" {
 variable "q_sidecar_version" {
   description = "Qumulo Sidecar software version"
   type        = string
-  default     = "5.1.0.1"
+  default     = "5.3.0"
   nullable    = false
   validation {
     condition     = can(regex("^((4\\.[2-3]\\.[0-9][0-9]?\\.?[0-9]?[0-9]?)|([5-9][0-9]?\\.[0-3]\\.[0-9][0-9]?\\.?[0-9]?[0-9]?))$", var.q_sidecar_version))


### PR DESCRIPTION
Next time we update cluster versions, the test suite will use the default `q_cluster_version` in `variables.tf`.